### PR TITLE
Change backend name: mmb is wrong #44

### DIFF
--- a/geniusyield-server-lib/src/GeniusYield/Server/Api.hs
+++ b/geniusyield-server-lib/src/GeniusYield/Server/Api.hs
@@ -268,7 +268,7 @@ mainServer = geniusYieldServer
 handleSettings ∷ Ctx → IO Settings
 handleSettings ctx@Ctx {..} = do
   logInfo ctx "Settings requested."
-  pure $ Settings {settingsNetwork = ctxNetworkId & customShowNetworkId, settingsVersion = showVersion PackageInfo.version, settingsRevision = gitHash, settingsBackend = "mmb", settingsAddress = fmap (addressToBech32 . Strict.snd) ctxSigningKey, settingsStakeAddress = ctxStakeAddress, settingsCollateral = ctxCollateral}
+  pure $ Settings {settingsNetwork = ctxNetworkId & customShowNetworkId, settingsVersion = showVersion PackageInfo.version, settingsRevision = gitHash, settingsBackend = "genius-server", settingsAddress = fmap (addressToBech32 . Strict.snd) ctxSigningKey, settingsStakeAddress = ctxStakeAddress, settingsCollateral = ctxCollateral}
 
 -- >>> customShowNetworkId GYMainnet
 -- "mainnet"


### PR DESCRIPTION
## Summary

Updated the backend name, since `mmb` is clearly wrong.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
